### PR TITLE
#53 - feat: LangChain4j 기반 AI 강사 추천 및 Vector DB 인덱싱 기본 구조 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,6 +60,11 @@ dependencies {
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
 
+    // LangChain4j & MongoDB Atlas Vector Store
+    implementation 'dev.langchain4j:langchain4j-open-ai-spring-boot-starter:0.35.0'
+    implementation 'dev.langchain4j:langchain4j-spring-boot-starter:1.18.1-beta28'
+    implementation 'dev.langchain4j:langchain4j-mongodb-atlas:0.35.0'
+
     // Test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'

--- a/src/main/java/com/lessonmatchingplatform/lesson_matching_platform/ai/controller/TutorRecommendationController.java
+++ b/src/main/java/com/lessonmatchingplatform/lesson_matching_platform/ai/controller/TutorRecommendationController.java
@@ -1,0 +1,30 @@
+package com.lessonmatchingplatform.lesson_matching_platform.ai.controller;
+
+import com.lessonmatchingplatform.lesson_matching_platform.ai.dto.request.TutorRecommendRequest;
+import com.lessonmatchingplatform.lesson_matching_platform.ai.dto.response.TutorRecommendationResponse;
+import com.lessonmatchingplatform.lesson_matching_platform.ai.service.TutorRecommendationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@RequestMapping("/api/ai")
+@RestController
+public class TutorRecommendationController {
+
+    private final TutorRecommendationService tutorRecommendationService;
+
+    @PostMapping("/recommend-tutors")
+    public ResponseEntity<List<TutorRecommendationResponse>> recommendTutors(
+            @RequestBody TutorRecommendRequest request
+    ) {
+        List<TutorRecommendationResponse> result = tutorRecommendationService.recommend(request);
+
+        return ResponseEntity.ok(result);
+    }
+}

--- a/src/main/java/com/lessonmatchingplatform/lesson_matching_platform/ai/dto/TutorProfileDto.java
+++ b/src/main/java/com/lessonmatchingplatform/lesson_matching_platform/ai/dto/TutorProfileDto.java
@@ -1,0 +1,61 @@
+package com.lessonmatchingplatform.lesson_matching_platform.ai.dto;
+
+import com.lessonmatchingplatform.lesson_matching_platform.account.type.GenderType;
+import com.lessonmatchingplatform.lesson_matching_platform.category.type.CategoryType;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public record TutorProfileDto(
+        Long tutorId,
+        String name,
+        GenderType gender,
+        String email,
+        String introduction,
+        String career,
+        String title,
+        String content,
+        Set<String> locations,
+        Set<CategoryType> categories,
+        Set<String> subjects
+) {
+
+    public String toPromptText() {
+
+        String categoriesText = (categories != null && !categories.isEmpty())
+                ? categories.stream().map(Enum::name).collect(Collectors.joining(", "))
+                : "미지정";
+
+        String locationsText = (locations != null && !locations().isEmpty())
+                ? String.join(", ", locations)
+                : "미지정";
+
+        String subjectsText = (subjects != null && !subjects.isEmpty())
+                ? String.join(", ", subjects)
+                : "미지정";
+
+        String genderText = (gender != null) ? gender.name() : "미지정";
+
+        return String.format("""
+                [강사 ID: %d | 이름: %s | 성별: %s]
+                - 대표 프로필 제목: %s
+                - 레슨 가능 지역: %s
+                - 카테고리/분야: %s
+                - 상세 과목: %s
+                - 주요 경력: %s
+                - 한줄 소개: %s
+                - 상세 설명/수업 방식: %s
+                """,
+                tutorId,
+                name,
+                genderText,
+                title != null ? title : "",
+                locationsText,
+                categoriesText,
+                subjectsText,
+                career != null ? career : "",
+                introduction != null ? introduction : "",
+                content != null ? content : ""
+        );
+    }
+}

--- a/src/main/java/com/lessonmatchingplatform/lesson_matching_platform/ai/dto/request/TutorRecommendRequest.java
+++ b/src/main/java/com/lessonmatchingplatform/lesson_matching_platform/ai/dto/request/TutorRecommendRequest.java
@@ -1,0 +1,6 @@
+package com.lessonmatchingplatform.lesson_matching_platform.ai.dto.request;
+
+public record TutorRecommendRequest(
+        String studentRequirement
+) {
+}

--- a/src/main/java/com/lessonmatchingplatform/lesson_matching_platform/ai/dto/response/TutorRecommendationResponse.java
+++ b/src/main/java/com/lessonmatchingplatform/lesson_matching_platform/ai/dto/response/TutorRecommendationResponse.java
@@ -1,0 +1,8 @@
+package com.lessonmatchingplatform.lesson_matching_platform.ai.dto.response;
+
+public record TutorRecommendationResponse(
+        Long tutorId,
+        String tutorName,
+        String recommendationReason
+) {
+}

--- a/src/main/java/com/lessonmatchingplatform/lesson_matching_platform/ai/service/TutorRecommendationAiService.java
+++ b/src/main/java/com/lessonmatchingplatform/lesson_matching_platform/ai/service/TutorRecommendationAiService.java
@@ -1,0 +1,32 @@
+package com.lessonmatchingplatform.lesson_matching_platform.ai.service;
+
+import com.lessonmatchingplatform.lesson_matching_platform.ai.dto.response.TutorRecommendationResponse;
+import dev.langchain4j.service.SystemMessage;
+import dev.langchain4j.service.UserMessage;
+import dev.langchain4j.service.V;
+import dev.langchain4j.service.spring.AiService;
+
+import java.util.List;
+
+@AiService
+public interface TutorRecommendationAiService {
+
+    @SystemMessage("""
+            너는 레슨 매칭 플랫폼의 전문 음악 강사 추천 AI 상담원이야.
+            제공된 [강사 목록]에서 학생의 [요청 사항]과 가장 잘 맞는 강사 3명을 선정해줘.
+            
+            각 강사별로 추천 이유(recommendationReason)를 학생의 요청 사항과 연관 지어 2줄 내외로 구체적으로 작성해줘.
+            """)
+    @UserMessage("""
+            [강사 목록]
+            {{tutorList}}
+            
+            [학생 요청 사항]
+            {{studentRequirement}}
+            """)
+
+    List<TutorRecommendationResponse> recommendTutors(
+            @V("tutorList") String tutorList,
+            @V("studentRequirement") String studentRequirement
+    );
+}

--- a/src/main/java/com/lessonmatchingplatform/lesson_matching_platform/ai/service/TutorRecommendationService.java
+++ b/src/main/java/com/lessonmatchingplatform/lesson_matching_platform/ai/service/TutorRecommendationService.java
@@ -1,0 +1,56 @@
+package com.lessonmatchingplatform.lesson_matching_platform.ai.service;
+
+import com.lessonmatchingplatform.lesson_matching_platform.ai.dto.request.TutorRecommendRequest;
+import com.lessonmatchingplatform.lesson_matching_platform.ai.dto.response.TutorRecommendationResponse;
+import dev.langchain4j.data.embedding.Embedding;
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.model.embedding.EmbeddingModel;
+import dev.langchain4j.store.embedding.EmbeddingSearchRequest;
+import dev.langchain4j.store.embedding.EmbeddingSearchResult;
+import dev.langchain4j.store.embedding.EmbeddingStore;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Transactional
+@RequiredArgsConstructor
+@Service
+public class TutorRecommendationService {
+
+    private final EmbeddingModel embeddingModel;
+    private final EmbeddingStore<TextSegment> embeddingStore;
+    private final TutorRecommendationAiService aiService;
+
+    public List<TutorRecommendationResponse> recommend(TutorRecommendRequest request) {
+        String studentRequirement = request.studentRequirement();
+
+        // 학생 요구사항 텍스트를 Vector로 변환
+        Embedding queryEmbedding = embeddingModel.embed(studentRequirement).content();
+
+        // Vector DB에서 의미적 유사도가 가장 높은 상위 10명의 강사만 Retrieval (1차 필터링)
+        EmbeddingSearchRequest searchRequest = EmbeddingSearchRequest.builder()
+                .queryEmbedding(queryEmbedding)
+                .maxResults(10)
+                .minScore(0.6)
+                .build();
+
+        EmbeddingSearchResult<TextSegment> searchResult = embeddingStore.search(searchRequest);
+
+        // 10명의 강사 프로필 텍스트를 하나의 Prompt 문자열로 결합
+        String candidateTutorsText = searchResult.matches().stream()
+                .map(match -> match.embedded().text())
+                .collect(Collectors.joining("\n---\n"));
+
+        if (candidateTutorsText.isBlank()) {
+            log.warn("Vector DB에서 조건에 맞는 강사를 찾지 못했습니다. requirement: {}", studentRequirement);
+            return List.of();
+        }
+
+        return aiService.recommendTutors(candidateTutorsText, studentRequirement);
+    }
+}

--- a/src/main/java/com/lessonmatchingplatform/lesson_matching_platform/ai/service/TutorVectorService.java
+++ b/src/main/java/com/lessonmatchingplatform/lesson_matching_platform/ai/service/TutorVectorService.java
@@ -1,0 +1,51 @@
+package com.lessonmatchingplatform.lesson_matching_platform.ai.service;
+
+import com.lessonmatchingplatform.lesson_matching_platform.ai.dto.TutorProfileDto;
+import dev.langchain4j.data.embedding.Embedding;
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.model.embedding.EmbeddingModel;
+import dev.langchain4j.store.embedding.EmbeddingStore;
+import dev.langchain4j.store.embedding.filter.Filter;
+import dev.langchain4j.store.embedding.filter.comparison.IsEqualTo;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import dev.langchain4j.data.document.Metadata;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class TutorVectorService {
+
+    private final EmbeddingModel embeddingModel;
+    private final EmbeddingStore<TextSegment> embeddingStore;
+
+    // 강사 프로필 등록/수정 시 Vector DB에 인덱싱
+    public void indexTutorProfile(TutorProfileDto tutorProfile) {
+        // 기존 벡터가 있다면 먼저 삭제 후 재등록 (수정 처리)
+        deleteTutorProfile(tutorProfile.tutorId());
+
+        // 강사 정보를 의미 단위 텍스트로 변환
+        String text = tutorProfile.toPromptText();
+
+        // 메타데이터(강사 ID)를 포함한 TextSegment 생성
+        Metadata metadata = Metadata.from("tutorId", String.valueOf(tutorProfile.tutorId()));
+        TextSegment segment = TextSegment.from(text, metadata);
+
+        // 텍스트를 임베딩(Vector)으로 변환 후 Vector DB에 저장
+        Embedding embedding = embeddingModel.embed(segment).content();
+        embeddingStore.add(embedding, segment);
+
+        log.info("Tutor Profile Indexed to Vector DB [TutorId: {}]", tutorProfile.tutorId());
+    }
+
+    public void deleteTutorProfile(Long tutorId) {
+        try {
+            Filter filter = new IsEqualTo("tutorId", String.valueOf(tutorId));
+            embeddingStore.removeAll(filter);
+            log.info("Tutor Profile Deleted from Vector DB [TutorId: {}]", tutorId);
+        } catch (Exception e) {
+            log.warn("Failed to delete tutor vector or store doesn't support removal by filter. TutorId: {}", tutorId, e);
+        }
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -62,3 +62,11 @@ toss:
   payments:
     secret-key: ${TOSS_SECRET:temp_toss_secret_key}
     confirm-url: https://api.tosspayments.com/v1/payments/confirm
+
+# LangChain4j
+langchain4j:
+  open-ai:
+    chat-model:
+      api-key: ${OPENAI_API_KEY} # 발급받은 API 키
+      model-name: gpt-4o-mini   # 속도가 빠르고 비용이 매우 저렴한 모델
+      temperature: 0.2


### PR DESCRIPTION
- LangChain4j 및 MongoDB Atlas Vector Store 설정 추가 (build.gradle, application.yml)
- 강사 프로필 텍스트를 임베딩(Vector)으로 변환 후 Vector DB에 저장/삭제하는 TutorVectorService 구현
- AI 강사 추천 요청 수신을 위한 Controller, DTO 및 Service 기본 레이어 구성 [주요 변경 사항]
1. TutorVectorService: 강사 프로필(TutorProfileDto) 텍스트 세그먼트 변환, 벡터 임베딩 생성/저장(indexTutorProfile) 및 기존 벡터 삭제(deleteTutorProfile) 구현
2. AI 추천 API 레이어 구성: TutorRecommendationController, DTO(TutorRecommendRequest, TutorRecommendationResponse) 작성
3. 의존성 및 환경설정: dev.langchain4j 라이브러리 추가 및 설정 반영